### PR TITLE
[SDK 113] Fixed GitHub Pages action not running for releases created from drafts

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -2,7 +2,7 @@ name: github_pages
 
 on:
   release:
-    types: [released, prereleased]
+    types: [published]
   workflow_dispatch:
 
 permissions: write-all


### PR DESCRIPTION
Changed event for `github_pages` action to run when a release is published instead of for 'released' or 'prereleased'