### PR TITLE
[SDK 156] Deprecate Kovan for Goerli

### DIFF
--- a/EnjinCSharpSDK/EnjinHosts.cs
+++ b/EnjinCSharpSDK/EnjinHosts.cs
@@ -19,23 +19,30 @@ using JetBrains.Annotations;
 namespace Enjin.SDK
 {
     /// <summary>
-    /// The networks hosts used by the Enjin Cloud.
+    /// The network hosts used by the Enjin Platform.
     /// </summary>
     [PublicAPI]
     public class EnjinHosts
     {
         /// <summary>
-        /// The URI for the kovan Enjin Cloud.
+        /// The URI for the Enjin Platform on the Goerli test network.
         /// </summary>
-        public static readonly Uri KOVAN = new Uri("https://kovan.cloud.enjin.io/");
-        
+        public static readonly Uri GOERLI = new Uri("https://goerli.cloud.enjin.io/");
+
         /// <summary>
-        /// The URI for the main Enjin Cloud.
+        /// The URI for the Enjin Platform on the Kovan test network.
+        /// </summary>
+        /// <deprecated>This host may no longer be supported. Use the <see cref="GOERLI"/> host.</deprecated>
+        [Obsolete("Kovan is deprecated, please use Goerli instead for a test network.", false)]
+        public static readonly Uri KOVAN = new Uri("https://kovan.cloud.enjin.io/");
+
+        /// <summary>
+        /// The URI for the Enjin Platform on the main network.
         /// </summary>
         public static readonly Uri MAIN_NET = new Uri("https://cloud.enjin.io/");
 
         /// <summary>
-        /// The URI for the JumpNet network.
+        /// The URI for the Enjin Platform on the JumpNet network.
         /// </summary>
         public static readonly Uri JUMP_NET = new Uri("https://jumpnet.cloud.enjin.io/");
     }

--- a/EnjinCSharpSDK/EnjinHosts.cs
+++ b/EnjinCSharpSDK/EnjinHosts.cs
@@ -30,13 +30,6 @@ namespace Enjin.SDK
         public static readonly Uri GOERLI = new Uri("https://goerli.cloud.enjin.io/");
 
         /// <summary>
-        /// The URI for the Enjin Platform on the Kovan test network.
-        /// </summary>
-        /// <deprecated>This host may no longer be supported. Use the <see cref="GOERLI"/> host.</deprecated>
-        [Obsolete("Kovan is deprecated, please use Goerli instead for a test network.", false)]
-        public static readonly Uri KOVAN = new Uri("https://kovan.cloud.enjin.io/");
-
-        /// <summary>
         /// The URI for the Enjin Platform on the main network.
         /// </summary>
         public static readonly Uri MAIN_NET = new Uri("https://cloud.enjin.io/");

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Create blockchain video games and applications using the C# programming language
 
 [Learn more](https://enjin.io/) about the Enjin blockchain platform.
 
-Sign up to Enjin Cloud: [Kovan (Testnet)](https://kovan.cloud.enjin.io/),
+Sign up to Enjin Cloud: [Goerli (Testnet)](https://goerli.cloud.enjin.io/),
 [Mainnet (Production)](https://cloud.enjin.io/) or [JumpNet](https://jumpnet.cloud.enjin.io/).
 
 ### Resources
@@ -55,8 +55,8 @@ public static class Program
     public static void Main()
     {
         // Builds the project client to run on the Kovan test network.
-        // See: https://kovan.cloud.enjin.io to sign up for the test network.
-        ProjectClient client = new ProjectClient(EnjinHosts.KOVAN);
+        // See: https://goerli.cloud.enjin.io/ to sign up for the test network.
+        ProjectClient client = new ProjectClient(EnjinHosts.GOERLI);
 
         // Creates the request to authenticate the client.
         // Replace the appropriate strings with the project's UUID and secret.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ public static class Program
     public static void Main()
     {
         // Builds the project client to run on the Kovan test network.
-        // See: https://goerli.cloud.enjin.io/ to sign up for the test network.
+        // See: https://goerli.cloud.enjin.io to sign up for the test network.
         ProjectClient client = new ProjectClient(EnjinHosts.GOERLI);
 
         // Creates the request to authenticate the client.

--- a/TestSuite/Unit/Events/EventTypeDefTest.cs
+++ b/TestSuite/Unit/Events/EventTypeDefTest.cs
@@ -27,8 +27,8 @@ namespace TestSuite
     public class EventTypeDefTest
     {
         [TestCase("project")]
-        [TestCase("enjincloud.kovan.wallet.0x0")]
-        [TestCase("enjincloud.kovan.wallet.0x0", "enjincloud.kovan.asset.0x0")]
+        [TestCase("enjincloud.test.wallet.0x0")]
+        [TestCase("enjincloud.test.wallet.0x0", "enjincloud.test.asset.0x0")]
         public void FilterByChannelTypes_ReturnsDefsWithChannelType(params string[] channels)
         {
             // Arrange


### PR DESCRIPTION
- Added Goerli host to `EnjinHosts`
- Deprecated Kovan host
- Updated `README.md` to use Goerli instead of Kovan